### PR TITLE
Fix of typo in VDA5050_EN.md

### DIFF
--- a/VDA5050_EN.md
+++ b/VDA5050_EN.md
@@ -1289,7 +1289,7 @@ If a parameter is not defined or set to zero then there is no explicit limit for
 |  &emsp;*visualizationInterval*      | float32       | [s], Default interval for sending messages on visualization topic.       |
 | }                             |               |                                                               |
 
-#### agvProtocolFeatures
+#### protocolFeatures
 
 This JSON object defines actions and parameters which are supported by the AGV.
 


### PR DESCRIPTION
Since it's still there, and none answered or handled it so far, here is how I assume it's supposed to be.

Resolves #107