### PR TITLE
ORDER_ERROR shall be sent repeatedly, so remove erroneous "not"

### DIFF
--- a/VDA5050_EN.md
+++ b/VDA5050_EN.md
@@ -629,7 +629,7 @@ Resolution:
 
 1. Vehicle does NOT take over the new order in its internal buffer 
 2. Vehicle reports the warning "orderError" with the wrong fields as error references
-3. The warning must not be reported until the vehicle has accepted a new order. 
+3. The warning must be reported until the vehicle has accepted a new order. 
 
 
 
@@ -638,7 +638,7 @@ Resolution:
 Resolution: 
 
 1. Vehicle does NOT take over the new order in its internal buffer. 
-2. Vehicle keeps the PREVIOUS order it its buffer. 
+2. Vehicle keeps the PREVIOUS order in its buffer. 
 3. The vehicle reports the warning "orderUpdateError"
 4. The vehicle continues with the executing the previous order. 
 


### PR DESCRIPTION
In chapter 6.6.4.2, until now the error reporting is described as
> The warning must **not** be reported until the vehicle has accepted a new order.

As undouptedly discussed in #102, the `not` in above sentence is wrong and should be removed.

This would solve the first bullet point of the first section of #102:
> * Is there a reason why in the one case the error shall be repeatedly sent, in the other case not (sorry if this was already discussed, I appreciate a link to the discussion in this case)