### PR TITLE
Fixed Typo agvProtocolFeatures to protocolFeatures

### DIFF
--- a/VDA5050_EN.md
+++ b/VDA5050_EN.md
@@ -1292,7 +1292,7 @@ If a parameter is not defined or set to zero then there is no explicit limit for
 |  &emsp;*visualizationInterval*      | float32       | [s], Default interval for sending messages on visualization topic.       |
 | }                             |               |                                                               |
 
-#### agvProtocolFeatures
+#### protocolFeatures
 
 This JSON object defines actions and parameters which are supported by the AGV.
 


### PR DESCRIPTION
Fixed Typo in protocol line 1295 from agvProtocolFeatures to protocolFeatures as defined in table line 1220.
Resolves Issue from PR #161 accoirdung to @Tirine.