### PR TITLE
Fixes error in node travesal description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VDA5050 - Version 2.1.0
+# VDA5050
 
 An open standard for communication between AGV fleets and a central master control. Developed jointly by the German Association of the Automotive Industry (www.vda.de) and the Mechanical Engineering Industry Association (www.vdma.org), as well as the Institute for Material Flow and Logistics (IFL) at KIT (www.ifl.kit.edu) and many contributors from the AMR industry.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VDA5050
+# VDA5050 - Version 2.1.0
 
 An open standard for communication between AGV fleets and a central master control. Developed jointly by the German Association of the Automotive Industry (www.vda.de) and the Mechanical Engineering Industry Association (www.vdma.org), as well as the Institute for Material Flow and Logistics (IFL) at KIT (www.ifl.kit.edu) and many contributors from the AMR industry.
 

--- a/VDA5050_EN.md
+++ b/VDA5050_EN.md
@@ -980,7 +980,7 @@ The edge shall then be removed from the `edgeStates` and the actions that were a
 
 The traversal of the node also marks the moment, when the AGV enters the following edge, if there is one.
 The edge's actions shall now be triggered.
-An exception to this rule is, if the AGV has to pause on the edge (because of a soft or hard blocking edge, or otherwise) – then the AGV enters the edge after it begins moving again.
+An exception to this rule is, if the AGV has to pause on the node (because of a soft or hard blocking action, or otherwise) – then the AGV enters the edge after it begins moving again.
 
 ![Figure 15 Depiction of nodeStates, edgeStates, and actionStates during order handling](./assets/states_during_order_handling.png)
 >Figure 15 Depiction of `nodeStates`, `edgeStates`, and `actionStates` during order handling


### PR DESCRIPTION
In section 6.10.2 the behavirour of traversing nodes is described incorrectly. 
It is said that the AGV has to pause on an edge potentially due to a hard blocking edge. 

There is no prior reference to a hard blcoking edge, but rather hard blocking actions. Furthermore the pausing should likely take place on the node rather than the edge. Particulary because it is followed by the statement that the AGV will enter the Edge after the pause, which would not be possible if the AGV was already on said edge.

Furthermore the following figure (Figure 15) illustrates a case where an AGV stops on a node until the blocking action is finished and only then proceeds to the edge.