### PR TITLE
Bugfix allowedDeviationTheta in the order schema

### DIFF
--- a/json_schemas/order.schema
+++ b/json_schemas/order.schema
@@ -120,7 +120,7 @@
                             },
                             "allowedDeviationTheta": {
                                 "type": "number",
-                                "minimum": -3.141592654,
+                                "minimum": 0.0,
                                 "maximum": 3.141592654,
                                 "description": "Indicates how big the deviation of theta angle can be. \nThe lowest acceptable angle is theta - allowedDeviationTheta and the highest acceptable angle is theta + allowedDeviationTheta."
                             },


### PR DESCRIPTION
As per Issue https://github.com/VDA5050/VDA5050/issues/314, I've fixed the incorrect minimum value for allowedDeviationTheta in order.schema to align it with the main document.

This change can be made directly in the main branch since the leading document is the published PDF by the VDA. The schemas should accurately reflect the tables in that document.