### PR TITLE
Rename “AGV” to “mobile robot” in document

### DIFF
--- a/VDA5050_EN.md
+++ b/VDA5050_EN.md
@@ -1,6 +1,6 @@
 ![logo](./assets/logo.png)
 
-# Interface for the communication between automated guided vehicles (AGV) and a master control
+# Interface for the communication between mobile robots and a master control
 
 ## VDA 5050
 


### PR DESCRIPTION
To demonstrate the broad applicability of VDA 5050, we are removing the term “AGV” throughout the document.
Version 3.0 now supports every class of mobile robot—including line-guided, virtually line-guided, and freely navigating vehicles.

The acronym “AGV” is commonly associated with strictly path-bound vehicles, which has led some readers to assume that VDA 5050 applies only to track-bound systems.

Note: Before release, the document will be thoroughly reviewed to replace every instance of “AGV” with “mobile robot” or, where appropriate, simply “vehicle.”