### PR TITLE
Add mapDescription to visualization schema

### DIFF
--- a/json_schemas/visualization.schema
+++ b/json_schemas/visualization.schema
@@ -56,6 +56,9 @@
                 "mapId": {
                     "type": "string"
                 },
+                "mapDescription": {
+                    "type": "string"
+                },
                 "positionInitialized": {
                     "type": "boolean",
                     "description": "True if the AGVs position is initialized, false, if position is not initizalized."


### PR DESCRIPTION
The documentation for the visualization topic states:

> The structure of the position object is the same as the position and velocity object in the state.

However, the agvPosition object in the visualization schema does not currently list the mapDescription property.