### PR TITLE
Added request/response chapter

### DIFF
--- a/VDA5050_EN.md
+++ b/VDA5050_EN.md
@@ -434,8 +434,7 @@ Each request is represented on the mobile robot by a request object (e.g. zoneRe
 
 The field requestStatus describes the life cycle of the request and shall support the following values:
     - 'REQUESTED': Vehicle request. 
-- 'GRANTED': The master control grants the request.
-- ```
+    - 'GRANTED': The master control grants the request.
 	- 'REVOKED': master control revokes previously granted request. 
 	- 'REJECTED': master control rejects a request. 
 	- 'QUEUED': Acknowledge the vehicle's request to the master control, but no permission is given yet. Request was added to some sort of a queue.


### PR DESCRIPTION
Requests/response chapter is currently used for requesting within interactive zones and release of corridors. To have this concept reusable, a central chapter was added.