### PR TITLE
replace two more "automated guided vehicle" with "mobile robot" 

### DIFF
--- a/VDA5050_EN.md
+++ b/VDA5050_EN.md
@@ -6,20 +6,20 @@
 
 ## Version 3.0.0 - Draft (not released by the VDA)
 
-![control system and automated guided vehicles](./assets/csagv.png)
+![control system and mobile robots](./assets/csagv.png)
 
 
 
 ### Brief information
 
 Definition of a communication interface for driverless transport systems (DTS).
-This recommendation describes the communication interface for exchanging order and status data between a central master control and automated guided vehicles (AGVs) for intralogistics processes.
+This recommendation describes the communication interface for exchanging order and status data between a central master control and mobile robots for intralogistics processes.
 
 
 
 ### Disclaimer
 
-The following explanations serve as an indication for the execution of an interface for communication between automated guided vehicles (AGVs) and master control and one that is freely applicable to everyone and is non-binding.
+The following explanations serve as an indication for the execution of an interface for communication between mobile robots and master control and one that is freely applicable to everyone and is non-binding.
 Those who apply them shall ensure that they are applied properly in the specific case.
 
 They shall take into account the state of the art prevailing at the time of each issue.


### PR DESCRIPTION
There were two more instances of "automated guided vehicle" in the brief information and the disclaimer. 

Also, 
assets/csagv.png
still states "automated guided vehicles", but I don't have the original file. 