### PR TITLE
Require instant/zoneActionStates in state message

### DIFF
--- a/json_schemas/state.schema
+++ b/json_schemas/state.schema
@@ -19,7 +19,6 @@
         "driving",
         "actionStates",
         "instantActionStates",
-        "zoneActionStates",
         "batteryState",
         "operatingMode",
         "errors",


### PR DESCRIPTION
Align with document.

Another option: make optional in both places