### PR TITLE
ActionId should not be a parameter of Action Zone definition

### DIFF
--- a/json_schemas/zoneSet.schema
+++ b/json_schemas/zoneSet.schema
@@ -280,10 +280,6 @@
                     "type": "string",
                     "description": "Name of action as described in the first column of \"Actions and Parameters\". Identifies the function of the action."
                 },
-                "actionId": {
-                    "type": "string",
-                "description": "Unique ID to identify the action and map them to the actionState in the state. Suggestion: Use UUIDs."
-                },
                 "actionDescriptor": {
                     "type": "string",
                     "description": "Additional information on the action."


### PR DESCRIPTION
Removed actionId as a property in the ACTION zone definition, since the actionId is to be generated by the mobile robot during runtime preferable as UUID.

Issue #460 