### PR TITLE
Rework make velocity and vx mandatory

### DIFF
--- a/VDA5050_EN.md
+++ b/VDA5050_EN.md
@@ -1690,7 +1690,7 @@ mapId <br> } | | string | Unique identification of the map in which the position
 Object structure | Unit | Data type | Description
 ---|---|---|---
 **velocity** { | | JSON object |
-vx | m/s | float64 | The mobile robot's velocity in its X-direction.
+*vx* | m/s | float64 | The mobile robot's velocity in its X-direction.
 *vy* | m/s | float64 | The mobile robot's velocity in its Y-direction.
 *omega*<br>}| rad/s | float64 | The mobile robot's turning speed around its Z-axis.
 

--- a/json_schemas/state.schema
+++ b/json_schemas/state.schema
@@ -368,9 +368,6 @@
         "velocity": {
             "type": "object",
             "description": "The mobile robot's velocity in mobile robot coordinates",
-            "required": [
-                "vx"
-            ],
             "properties": {
                 "vx": {
                     "type": "number",


### PR DESCRIPTION
The velocity object shall always be transmitted, within it the vx is mandatory.