### PR TITLE
Alignment of polygons are used for zones and the envelope2d

### DIFF
--- a/VDA5050_EN.md
+++ b/VDA5050_EN.md
@@ -2052,7 +2052,7 @@ This JSON object defines the geometry properties of the mobile robot, e.g., outl
 | } | | |
 | ***envelopes2d** [**envelope2d**]* | array | Array of mobile robot envelope curves in 2D, e.g., the mechanical envelopes for unloaded and loaded state, the safety fields for different speed cases. |
 | { | | |
-| &emsp;envelopes2dId | string | Identifier of the envelope curve set. |
+| &emsp;envelope2dId | string | Identifier of the envelope curve set. |
 | &emsp;**vertices[vertex]** | array | The envelope curve in form of a polygon. It shall be assumed as closed. Only simple polygons shall be used. |
 | &emsp;{ | | |
 |&emsp;&emsp; x | float64 | [m], X-position of polygon point. |
@@ -2062,7 +2062,7 @@ This JSON object defines the geometry properties of the mobile robot, e.g., outl
 | *}* | | |
 | ***envelopes3d [envelope3d]*** | array | Array of mobile robot envelope curves in 3D. |
 | *{* | | |
-| &emsp;envelopes3dId | string | Identifier of the envelope curve set. |
+| &emsp;envelope3dId | string | Identifier of the envelope curve set. |
 | &emsp;format | string | Format of data, e.g., DXF. |
 | &emsp;***data*** | JSON object | 3D-envelope curve data, format specified in 'format'. |
 | &emsp;*url* | string | Protocol and URL definition for downloading the 3D-envelope curve data, e.g., <ftp://xxx.yyy.com/ac4dgvhoif5tghji>. |

--- a/json_schemas/factsheet.schema
+++ b/json_schemas/factsheet.schema
@@ -556,13 +556,13 @@
                     "items": {
                         "type": "object",
                         "required": [
-                            "setName",
+                            "envelope2dId",
                             "vertices"
                         ],
                         "properties": {
-                            "setName": {
+                            "envelope2dId": {
                                 "type": "string",
-                                "description": "Name of the envelope curve set"
+                                "description": "Identifier of the envelope curve set."
                             },
                             "vertices": {
                                 "type": "array",
@@ -600,13 +600,13 @@
                     "items": {
                         "type": "object",
                         "required": [
-                            "set",
+                            "envelope3dId",
                             "format"
                         ],
                         "properties": {
-                            "set": {
+                            "envelope3dId": {
                                 "type": "string",
-                                "description": "Name of the envelope curve set"
+                                "description": "Identifier of the envelope curve set."
                             },
                             "format": {
                                 "type": "string",


### PR DESCRIPTION
Polygones shall always be assumed as closed and only simple polygones shall be used. Vertices are now used for the envelope2d to show, that these are the same concept.

The concept was already there, we now aligned them. I also simplified the description of an implicitly closed polygon, as this concept already existed in VDA 5050 for envelopes.

Note: Rename of set variable of envelope2d to setName to show what the intension was