### PR TITLE
Added remark on CRITICAL and FATAL errors for robot not continuing driving, when this error occurs.

### DIFF
--- a/VDA5050_EN.md
+++ b/VDA5050_EN.md
@@ -1105,9 +1105,9 @@ The mobile robot reports issues that it wants to inform the operator about via t
 #### 6.6.5.1 Error levels
 The issues can have four levels: 'WARNING', 'URGENT', 'CRITICAL', and 'FATAL'.
 
-- A 'WARNING' level issue does not require immediate attention. The mobile robot can continue its current order and take new orders. The error might be self-resolving, e.g., a dirty LiDar-scanner.
+- A 'WARNING' level issue does not require immediate attention. The mobile robot can continue its current order and is able to take new orders. The error might be self-resolving, e.g., a dirty LiDar-scanner.
 - An 'URGENT' level issue requires immediate attention, e.g., a low battery level. The mobile robot can continue its current order, and is able to take new orders.
-- A 'CRITICAL' level issue requires immediate attention, e.g., trying to pick an object, that is not there. The mobile robot shall not continue driving since since can not continue its current order, but is able to take new orders.
+- A 'CRITICAL' level issue requires immediate attention, e.g., trying to pick an object, that is not there. The mobile robot shall not continue driving since it can not continue its current order but is able to take new orders.
 - A 'FATAL' level issue requires user intervention, e.g., losing localization. The mobile robot shall not continue driving since it can neither continue its currently active order nor take any new orders.
 
 The mobile robot can add references that help with finding the cause of the error via the `errorReferences` array as well as `errorHints` to propose a possible resolution. Regardless of the level of the issue, the mobile robot shall never clear its order due to it.


### PR DESCRIPTION
This was prior to this change only implicitly assumed, now it is explicitly stated.

Discussion if to stop movement or only stop driving?

CRITICAL: might be only driving
FATAL: might also be movement